### PR TITLE
Filter internal events via hiding/showing views

### DIFF
--- a/lib/ipc-event-view.js
+++ b/lib/ipc-event-view.js
@@ -8,6 +8,7 @@ class IpcEventView extends SelectableView {
     super('ipc-table-row')
 
     this.event = event
+    this.internalEvent = event.channel.startsWith('ELECTRON_') || event.channel.startsWith('ATOM_')
     table.appendChild(this.element)
     this.listenForSelection(table)
     this.listenForSelectionKeys(table.parentElement)

--- a/lib/ipc-view.js
+++ b/lib/ipc-view.js
@@ -25,9 +25,15 @@ class IpcView extends View {
     if (this.hideInternal) {
       this.hideInternalButton.classList.remove('active')
       this.hideInternal = false
+      this.children.forEach((child) => {
+        if (child.internalEvent) child.show()
+      })
     } else {
       this.hideInternalButton.classList.add('active')
       this.hideInternal = true
+      this.children.forEach((child) => {
+        if (child.internalEvent) child.hide()
+      })
     }
   }
 
@@ -73,8 +79,9 @@ class IpcView extends View {
     ipc.getEvents().then((events) => {
       if (this.recording) {
         events.forEach((event) => {
-          if (this.hideInternal && this.isInternalEvent(event)) return
-          this.children.push(new IpcEventView(event, this.ipcTable))
+          const eventView = new IpcEventView(event, this.ipcTable)
+          this.children.push(eventView)
+          if (this.hideInternal && eventView.internalEvent) eventView.hide()
         })
 
         this.timeoutId = setTimeout(() => {


### PR DESCRIPTION
After playing with the filter internal ipc events toggle a bit more I found that it is nice to have them all and just hide/show them instead of completely ignoring them as the occur.
