### PR TITLE
Make all table rows white

### DIFF
--- a/static/devtron.css
+++ b/static/devtron.css
@@ -63,6 +63,11 @@
   background-color: white;
 }
 
+.table-striped tr:nth-child(even),
+.table-striped > tbody > tr:nth-of-type(odd) {
+  background-color: #fff;
+}
+
 .table-striped > tbody > tr.active,
 .table-striped > tbody > tr.active .row-directory,
 .table-striped > tbody > tr.active .listener-count {


### PR DESCRIPTION
Removes the striping from the tables to blend in better with the other dev tools tables
