### PR TITLE
expose the path of the extension

### DIFF
--- a/api.js
+++ b/api.js
@@ -8,3 +8,5 @@ exports.install = () => {
 exports.uninstall = () => {
   return electron.remote.BrowserWindow.removeDevToolsExtension('devtron')
 }
+
+exports.path = __dirname;


### PR DESCRIPTION
I need it for https://github.com/sindresorhus/electron-debug/pull/36

Currently I'm using `path.dirname(require.resolve('devtron'))`, but that will break if you move `api.js`.