### PR TITLE
crashed event warning

### DIFF
--- a/lib/lint-helpers.js
+++ b/lib/lint-helpers.js
@@ -11,9 +11,13 @@ exports.isUsingAsar = () => {
 
 exports.isListeningForCrashEvents = () => {
   return Eval.execute(() => {
-    const webContents = require('electron').remote.getCurrentWebContents()
-    // Electron has a crashed listener, so look for more than 1
-    return webContents.listenerCount('crashed') > 1
+    const remote = require('electron').remote
+    const webContents = remote.getCurrentWebContents()
+    // For versions less than 1.x.y
+    // Electron has an crashed listener, so look for more than 1
+    const crashedForwarding = /^0/.test(remote.process.versions.electron)
+    const minCount = crashedForwarding ? 1 : 0
+    return webContents.listenerCount('crashed') > minCount
   })
 }
 


### PR DESCRIPTION
[This commit](https://github.com/electron/electron/commit/76853801051be1dfbe94cb855567b5c901f9f12d) removed crashed event forwarding for tags `1.x.y`
![image](https://cloud.githubusercontent.com/assets/1622515/15265388/3b462260-19a0-11e6-9ace-32ef645e6663.png)
Fixes #67 
