### PR TITLE
Add error message if triggered from the main process

### DIFF
--- a/api.js
+++ b/api.js
@@ -1,6 +1,9 @@
 const electron = require('electron')
 
 exports.install = () => {
+  if (!electron.remote) {
+    throw new Error('Devtron cannot be installed from within the main process.')
+  }
   console.log(`Installing Devtron from ${__dirname}`)
   return electron.remote.BrowserWindow.addDevToolsExtension(__dirname)
 }


### PR DESCRIPTION
Right now, if you don't read the instructions—like me—and try to open Devtron from the main process, like you might do with `webContents.toggleDevTools()`, your Electron application will kick the bucket with a fairly cryptic error message.

<img width="532" alt="screen shot 2016-05-14 at 12 55 39 pm" src="https://cloud.githubusercontent.com/assets/251000/15269691/364228ec-19d5-11e6-9e18-102ea6767f29.png">

This pull request adds an error message that will throw an error message that makes it easier for the developer to see the mistake they made.