### PR TITLE
Fix lint active styles

### DIFF
--- a/lib/lint-view.js
+++ b/lib/lint-view.js
@@ -1,5 +1,6 @@
 'use strict'
 
+const highlight = require('highlight.js')
 const Lint = require('./lint-helpers')
 const View = require('./view')
 
@@ -7,10 +8,17 @@ class LintView extends View {
   constructor () {
     super('lint-view')
     this.handleEvents()
+    this.highlightBlocks()
   }
 
   reload () {
     this.lint()
+  }
+
+  highlightBlocks () {
+    highlight.highlightBlock(this.crashedExample)
+    highlight.highlightBlock(this.unresponsiveExample)
+    highlight.highlightBlock(this.uncaughtExample)
   }
 
   handleEvents () {

--- a/static/devtron.css
+++ b/static/devtron.css
@@ -328,3 +328,7 @@ code {
 .pane {
   overflow-y: hidden;
 }
+
+.lint-table .alert {
+  border-radius: 0;
+}

--- a/static/devtron.css
+++ b/static/devtron.css
@@ -331,4 +331,6 @@ code {
 
 .lint-table .alert {
   border-radius: 0;
+  background: #fff;
+  color: #333;
 }

--- a/static/devtron.css
+++ b/static/devtron.css
@@ -41,7 +41,8 @@
   border-width: 0;
 }
 
-.row-listener-event-code code {
+.row-listener-event-code code,
+.lint-code code {
   padding: 5px;
 }
 

--- a/static/index.html
+++ b/static/index.html
@@ -232,8 +232,6 @@
                   <p data-field="outdatedDescription">
                     Your application is using version <span data-field="versionLabel"></span>
                     and the latest version released is <span data-field="latestLabel"></span>.
-
-                    <br><br>
                     View the <a href="http://electron.atom.io/releases.html">Electron release notes</a>.
                   </p>
                 </td>
@@ -249,10 +247,7 @@
                     Your application is not bundled in an <code>.asar</code> archive.
                     Asar bundles your entire application into a single file which
                     makes your app quicker to install/update as well as improves the
-                    code loading performance in many environments.
-
-                    <br><br>
-                    View the <a href="http://electron.atom.io/docs/latest/tutorial/application-packaging">asar instructions</a>.
+                    code loading performance in many environments. View the <a href="http://electron.atom.io/docs/latest/tutorial/application-packaging">asar instructions</a>.
                   </p>
                 </td>
               </tr>
@@ -267,12 +262,11 @@
                     Your application is not listening for the <code>crashed</code> event on
                     the <code>webContents</code> property of the <code>BrowserWindow</code>.
                     It is important to listen for this event to report when it happens
-                    and notify the user about what happened.
+                    and notify the user about what happened. View the <a href="http://electron.atom.io/docs/latest/api/web-contents/#event-crashed">docs</a>.
 
                     <br><br>
-                    Listen for this event by adding: <code>myWindow.webContents.on('crashed', function () { })</code>
-                    <br>
-                    View the <a href="http://electron.atom.io/docs/latest/api/web-contents/#event-crashed">docs</a>.
+                    Listen for this event by adding the following to the <code>BrowserWindow</code>:
+                    <pre class="lint-code "><code class="language-javascript" data-field="crashedExample">myWindow.webContents.on('crashed', function () { })</code></pre>
                   </p>
                 </td>
               </tr>
@@ -287,12 +281,11 @@
                     Your application is not listening for the <code>unresponsive</code> event on
                     the <code>BrowserWindow</code>. It is important to listen for this
                     event to report when it happens and to notify the user about what
-                    has happened.
+                    has happened. View the <a href="http://electron.atom.io/docs/latest/api/browser-window/#event-unresponsive">docs</a>.
 
                     <br><br>
-                    Listen for this event by adding: <code>myWindow.on('unresponsive', function () { })</code>
-                    <br>
-                    View the <a href="http://electron.atom.io/docs/latest/api/browser-window/#event-unresponsive">docs</a>.
+                    Listen for this event by adding the following <code>WebContents</code>:
+                    <pre class="lint-code"><code class="language-javascript" data-field="unresponsiveExample">myWindow.on('unresponsive', function () { })</code></pre>
                   </p>
                 </td>
               </tr>
@@ -308,12 +301,11 @@
                     event on the main <code>process</code>. Electron shows a dialog with a
                     stack trace by default if you do not provide a listener for this event.
                     It is important to listen for this event to report when it happens
-                    and possibly notify the user about what has happened.
+                    and possibly notify the user about what has happened. View the <a href="https://nodejs.org/api/process.html#process_event_uncaughtexception">docs</a>.
 
                     <br><br>
-                    Listen for this event by adding <code>process.on('uncaughtException', function () { })</code> in the main process.
-                    <br>
-                    View the <a href="https://nodejs.org/api/process.html#process_event_uncaughtexception">docs</a>.
+                    Listen for this event by adding the following to the main process:
+                    <pre class="lint-code"><code class="language-javascript" data-field="uncaughtExample">process.on('uncaughtException', function () { })</code></pre>
                   </p>
                 </td>
               </tr>

--- a/static/index.html
+++ b/static/index.html
@@ -247,7 +247,7 @@
                     Your application is not bundled in an <code>.asar</code> archive.
                     Asar bundles your entire application into a single file which
                     makes your app quicker to install/update as well as improves the
-                    code loading performance in many environments. View the <a href="http://electron.atom.io/docs/latest/tutorial/application-packaging">asar instructions</a>.
+                    code loading performance in many environments. View the <a href="http://electron.atom.io/docs/tutorial/application-packaging">asar instructions</a>.
                   </p>
                 </td>
               </tr>
@@ -262,7 +262,7 @@
                     Your application is not listening for the <code>crashed</code> event on
                     the <code>webContents</code> property of the <code>BrowserWindow</code>.
                     It is important to listen for this event to report when it happens
-                    and notify the user about what happened. View the <a href="http://electron.atom.io/docs/latest/api/web-contents/#event-crashed"><code>BrowserWindow</code> docs</a>.
+                    and notify the user about what happened. View the <a href="http://electron.atom.io/docs/api/web-contents/#event-crashed"><code>BrowserWindow</code> docs</a>.
 
                     <br><br>
                     Listen for this event by adding the following to the <code>BrowserWindow</code>:
@@ -281,7 +281,7 @@
                     Your application is not listening for the <code>unresponsive</code> event on
                     the <code>BrowserWindow</code>. It is important to listen for this
                     event to report when it happens and to notify the user about what
-                    has happened. View the <a href="http://electron.atom.io/docs/latest/api/browser-window/#event-unresponsive"><code>WebContents</code> docs</a>.
+                    has happened. View the <a href="http://electron.atom.io/docs/api/browser-window/#event-unresponsive"><code>WebContents</code> docs</a>.
 
                     <br><br>
                     Listen for this event by adding the following <code>WebContents</code>:

--- a/static/index.html
+++ b/static/index.html
@@ -265,7 +265,7 @@
                     and notify the user about what happened. View the <a href="http://electron.atom.io/docs/api/web-contents/#event-crashed"><code>BrowserWindow</code> docs</a>.
 
                     <br><br>
-                    Listen for this event by adding the following to the <code>BrowserWindow</code>:
+                    Listen for this event by adding the following to the <code>webContents</code>:
                     <pre class="lint-code "><code class="language-javascript" data-field="crashedExample">myWindow.webContents.on('crashed', function () { })</code></pre>
                   </p>
                 </td>
@@ -284,7 +284,7 @@
                     has happened. View the <a href="http://electron.atom.io/docs/api/browser-window/#event-unresponsive"><code>WebContents</code> docs</a>.
 
                     <br><br>
-                    Listen for this event by adding the following <code>WebContents</code>:
+                    Listen for this event by adding the following to the <code>BrowserWindow</code>:
                     <pre class="lint-code"><code class="language-javascript" data-field="unresponsiveExample">myWindow.on('unresponsive', function () { })</code></pre>
                   </p>
                 </td>

--- a/static/index.html
+++ b/static/index.html
@@ -304,7 +304,7 @@
                     and possibly notify the user about what has happened. View the <a href="https://nodejs.org/api/process.html#process_event_uncaughtexception"><code>process</code> docs</a>.
 
                     <br><br>
-                    Listen for this event by adding the following to the main process:
+                    Listen for this event by adding the following to the main <code>process</code>:
                     <pre class="lint-code"><code class="language-javascript" data-field="uncaughtExample">process.on('uncaughtException', function () { })</code></pre>
                   </p>
                 </td>

--- a/static/index.html
+++ b/static/index.html
@@ -262,7 +262,7 @@
                     Your application is not listening for the <code>crashed</code> event on
                     the <code>webContents</code> property of the <code>BrowserWindow</code>.
                     It is important to listen for this event to report when it happens
-                    and notify the user about what happened. View the <a href="http://electron.atom.io/docs/api/web-contents/#event-crashed"><code>BrowserWindow</code> docs</a>.
+                    and notify the user about what happened. View the <a href="http://electron.atom.io/docs/api/web-contents/#event-crashed"><code>webContents</code> docs</a>.
 
                     <br><br>
                     Listen for this event by adding the following to the <code>webContents</code>:
@@ -281,7 +281,7 @@
                     Your application is not listening for the <code>unresponsive</code> event on
                     the <code>BrowserWindow</code>. It is important to listen for this
                     event to report when it happens and to notify the user about what
-                    has happened. View the <a href="http://electron.atom.io/docs/api/browser-window/#event-unresponsive"><code>WebContents</code> docs</a>.
+                    has happened. View the <a href="http://electron.atom.io/docs/api/browser-window/#event-unresponsive"><code>BrowserWindow</code> docs</a>.
 
                     <br><br>
                     Listen for this event by adding the following to the <code>BrowserWindow</code>:

--- a/static/index.html
+++ b/static/index.html
@@ -218,7 +218,7 @@
         </header>
 
         <div class="table-scroller">
-          <table class="table-striped" tabindex="-1">
+          <table class="table-striped lint-table" tabindex="-1">
             <thead>
               <th>Lint Checks</th>
             </thead>

--- a/static/index.html
+++ b/static/index.html
@@ -262,7 +262,7 @@
                     Your application is not listening for the <code>crashed</code> event on
                     the <code>webContents</code> property of the <code>BrowserWindow</code>.
                     It is important to listen for this event to report when it happens
-                    and notify the user about what happened. View the <a href="http://electron.atom.io/docs/latest/api/web-contents/#event-crashed">docs</a>.
+                    and notify the user about what happened. View the <a href="http://electron.atom.io/docs/latest/api/web-contents/#event-crashed"><code>BrowserWindow</code> docs</a>.
 
                     <br><br>
                     Listen for this event by adding the following to the <code>BrowserWindow</code>:
@@ -281,7 +281,7 @@
                     Your application is not listening for the <code>unresponsive</code> event on
                     the <code>BrowserWindow</code>. It is important to listen for this
                     event to report when it happens and to notify the user about what
-                    has happened. View the <a href="http://electron.atom.io/docs/latest/api/browser-window/#event-unresponsive">docs</a>.
+                    has happened. View the <a href="http://electron.atom.io/docs/latest/api/browser-window/#event-unresponsive"><code>WebContents</code> docs</a>.
 
                     <br><br>
                     Listen for this event by adding the following <code>WebContents</code>:
@@ -301,7 +301,7 @@
                     event on the main <code>process</code>. Electron shows a dialog with a
                     stack trace by default if you do not provide a listener for this event.
                     It is important to listen for this event to report when it happens
-                    and possibly notify the user about what has happened. View the <a href="https://nodejs.org/api/process.html#process_event_uncaughtexception">docs</a>.
+                    and possibly notify the user about what has happened. View the <a href="https://nodejs.org/api/process.html#process_event_uncaughtexception"><code>process</code> docs</a>.
 
                     <br><br>
                     Listen for this event by adding the following to the main process:


### PR DESCRIPTION
- Override a few photon styles for `:active` pseudo selector to fix selection bug in lint view
- Syntax highlight code blocks for consistency

Fixes #64