### PR TITLE
Add Chrome APIs from custom classes

### DIFF
--- a/lib/chrome-helpers.js
+++ b/lib/chrome-helpers.js
@@ -1,15 +1,39 @@
 'use strict'
 
-const findChromeAPIs = (apis, parent, object) => {
-  for (const property in object) {
-    const api = parent + '.' + property
-    if (typeof object[property] === 'object') {
-      findChromeAPIs(apis, api, object[property])
-    } else {
-      apis.push(api)
-    }
-  }
-  return apis
+const objectPrototype = Object.getPrototypeOf({})
+
+const isCustomClass = (object, prototype) => {
+  if (typeof object !== 'object') return false
+  if (Array.isArray(object)) return false
+
+  return prototype && prototype !== objectPrototype
 }
 
-exports.getChromeAPIs = () => findChromeAPIs([], 'chrome', window.chrome)
+
+const checkAPI = (apis, parent, name, value) => {
+  const api = parent + '.' + name
+  if (typeof value === 'object') {
+    findChromeAPIs(apis, api, value)
+  } else {
+    apis[api] = true
+  }
+}
+
+const findChromeAPIs = (apis, parent, object) => {
+  for (const name in object) {
+    checkAPI(apis, parent, name, object[name])
+  }
+
+  const prototype = Object.getPrototypeOf(object)
+  if (isCustomClass(object, prototype)) {
+    Object.getOwnPropertyNames(prototype).filter((name) => {
+      return name !== 'constructor'
+    }).forEach((name) => {
+      checkAPI(apis, parent, name, object[name])
+    })
+  }
+
+  return Object.keys(apis)
+}
+
+exports.getChromeAPIs = () => findChromeAPIs({}, 'chrome', window.chrome)

--- a/lib/chrome-helpers.js
+++ b/lib/chrome-helpers.js
@@ -9,7 +9,6 @@ const isCustomClass = (object, prototype) => {
   return prototype && prototype !== objectPrototype
 }
 
-
 const checkAPI = (apis, parent, name, value) => {
   const api = parent + '.' + name
   if (typeof value === 'object') {

--- a/test/unit/devtools.js
+++ b/test/unit/devtools.js
@@ -2,6 +2,12 @@
 
 const vm = require('vm')
 
+class Extension {
+  getURL () {
+    return 'file:///foo/bar.html'
+  }
+}
+
 exports.create = () => {
   const devtron = {}
   return {
@@ -33,9 +39,7 @@ exports.create = () => {
         },
         tabId: 1
       },
-      extension: {
-        getURL: () => 'file:///foo/bar.html'
-      }
+      extension: new Extension()
     }
   }
 }


### PR DESCRIPTION
I noticed `chrome.tabs.onRemoved.addListener` was missing from https://github.com/electron/electron/issues/5842 even though it appeared to be implemented at https://github.com/electron/electron/blob/7e7186933f4a979aecb841dd752a220992fbe1e3/lib/renderer/chrome-api.js#L173

It was due to the fact that some APIs use ES6 classes and `for in` loops don't iterate over them.

This pull request iterates over the prototype properties to include them.

/cc @jlord 