### PR TITLE
Don't install Devtron if it is already installed

### DIFF
--- a/api.js
+++ b/api.js
@@ -3,9 +3,13 @@ const electron = require('electron')
 exports.install = () => {
   if (process.type === 'renderer') {
     console.log(`Installing Devtron from ${__dirname}`)
+    if (electron.remote.BrowserWindow.getDevToolsExtensions &&
+        electron.remote.BrowserWindow.getDevToolsExtensions().devtron) return true
     return electron.remote.BrowserWindow.addDevToolsExtension(__dirname)
   } else if (process.type === 'browser') {
     console.log(`Installing Devtron from ${__dirname}`)
+    if (electron.BrowserWindow.getDevToolsExtensions &&
+        electron.BrowserWindow.getDevToolsExtensions().devtron) return true
     return electron.BrowserWindow.addDevToolsExtension(__dirname)
   } else {
     throw new Error('Devtron can only be installed from an Electron process.')


### PR DESCRIPTION
This prevents the "already installed" error in console