### PR TITLE
bump node version in appveyor config

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,7 +9,7 @@ branches:
 skip_tags: true
 
 environment:
-  nodejs_version: "4.4.3"
+  nodejs_version: "4.8.4"
 
 cache:
   - node_modules -> package.json


### PR DESCRIPTION
AppVeyor CI is failing:

<img width="996" alt="screen shot 2017-09-11 at 8 36 08 pm" src="https://user-images.githubusercontent.com/2289/30307124-dd34920a-9730-11e7-8263-a83e1b413aa1.png">


Looks like `Buffer.alloc` was added in Node 4.5.0: https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V4.md#4.5.0