### PR TITLE
fix: move "types" field above "import" in package exports

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,19 +5,19 @@
   "types": "./dist/types/index.d.ts",
   "exports": {
     ".": {
+      "types": "./dist/types/index.d.ts",
       "import": "./dist/mjs/index.mjs",
-      "require": "./dist/cjs/index.cjs",
-      "types": "./dist/types/index.d.ts"
+      "require": "./dist/cjs/index.cjs"
     },
     "./service-worker-preload": {
+      "types": "./dist/types/lib/service-worker-preload.d.ts",
       "import": "./dist/mjs/service-worker-preload.mjs",
-      "require": "./dist/cjs/service-worker-preload.cjs",
-      "types": "./dist/types/lib/service-worker-preload.d.ts"
+      "require": "./dist/cjs/service-worker-preload.cjs"
     },
     "./renderer-preload": {
+      "types": "./dist/types/lib/renderer-preload.d.ts",
       "import": "./dist/mjs/renderer-preload.mjs",
-      "require": "./dist/cjs/renderer-preload.cjs",
-      "types": "./dist/types/lib/renderer-preload.d.ts"
+      "require": "./dist/cjs/renderer-preload.cjs"
     }
   },
   "scripts": {


### PR DESCRIPTION
#### Description of Change
- Moves the types field at the top (above "import" and "require") in the `package.json` file.
- This fixes Vitest warnings about the "types" condition being ignored when it comes after "import" and "require":

```shell
▲ [WARNING] The condition "types" here will never be used as it comes after both "import" and "require" [package.json]

    package.json:20:6:
      20 │       "types": "./dist/types/lib/renderer-preload.d.ts"
         ╵       ~~~~~~~

  The "import" condition comes earlier and will be used for all "import" statements:

    package.json:18:6:
      18 │       "import": "./dist/mjs/renderer-preload.mjs",
         ╵       ~~~~~~~~

  The "require" condition comes earlier and will be used for all "require" calls:

    package.json:19:6:
      19 │       "require": "./dist/cjs/renderer-preload.cjs",
         ╵       ~~~~~~~~~
```