### PR TITLE
build: don't run prettier on GHA workflows

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,9 +33,8 @@ jobs:
           cache: 'npm'
       - name: Install dependencies
         run: npm ci
-      # TODO(dsanders11): Enable this once we get a clean lint state on `main`
-      # - name: Lint
-      #   run: npm run lint
+      - name: Lint
+        run: npm run lint
       - name: Build
         run: npm run build
       - name: Test

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,1 @@
+.github/workflows


### PR DESCRIPTION
We copy-paste around the same workflows across our ecosystem repos, and it's useful if they don't meaningfully diverge, so skip linting them here which would force formatting changes.