### PR TITLE
test: extend wait time to capture devtron SW reliably

### DIFF
--- a/spec/devtron-install-spec.ts
+++ b/spec/devtron-install-spec.ts
@@ -128,7 +128,7 @@ describe('Tracking IPC Events', () => {
       return 'handled';
     });
 
-    await delay(300); // If some test fails when it shouldn't, try increasing this delay
+    await delay(1500); // If some test fails when it shouldn't, try increasing this delay
     registerDevtronIpc();
 
     mainWindow.webContents.send('test-renderer-on', 'arg1', 'arg2');


### PR DESCRIPTION
#### Description of Change
- Increased the delay to ensure the Devtron service worker starts before being captured in tests.  
- Prevents test errors when the service worker isn’t immediately available.
