### PR TITLE
chore: remove unnecessary as any type assertion

### DIFF
--- a/src/extension/background/index.ts
+++ b/src/extension/background/index.ts
@@ -92,5 +92,5 @@ chrome.runtime.onConnect.addListener((port) => {
   }
 });
 
-(globalThis as any).addIpcEvent = addIpcEvent;
-(globalThis as any).returnIpcEvents = returnIpcEvents;
+globalThis.addIpcEvent = addIpcEvent;
+globalThis.returnIpcEvents = returnIpcEvents;


### PR DESCRIPTION
Should be unnecessary thanks to the typings in `global.d.ts`.