### PR TITLE
fix: disable row animations due to glitches at max row limit

### DIFF
--- a/src/extension/react/components/Panel.tsx
+++ b/src/extension/react/components/Panel.tsx
@@ -405,6 +405,7 @@ function Panel() {
             suppressCellFocus={true}
             headerHeight={25}
             rowHeight={29}
+            animateRows={false}
             enableFilterHandlers={true}
           />
         </div>


### PR DESCRIPTION
#### Description of Change
- This PR disables row animations in the events table.
- Animations behaved correctly while rows were below the maximum limit (`MAX_EVENTS_TO_DISPLAY = 20000`): when a new row was added, existing rows shifted upward smoothly.
- However, once the row limit was reached, each new event required removing the oldest row to maintain the limit. This caused the animations to appear weird and visually inconsistent.
- To ensure a stable and consistent visual experience, row animations have been disabled.

#### Behavior Comparison
- In both cases, the number of events has exceeded `MAX_EVENTS_TO_DISPLAY` for demonstration.

| With animations (before) | Without animations (after) |
|--------------------------|----------------------------|
| ![m7vuwsmgX1](https://github.com/user-attachments/assets/c98bf221-0c06-4a4c-b884-0b6a98dc59aa) | ![LHDgsnJXdT](https://github.com/user-attachments/assets/d3aa9557-50b3-4059-91f3-64cd8346de95) |
