### PR TITLE
test: wait for service worker using `runningStatus`

### DIFF
--- a/spec-electron-setup/scripts/mocha-cli.ts
+++ b/spec-electron-setup/scripts/mocha-cli.ts
@@ -12,7 +12,7 @@ const __dirname = path.dirname(__filename);
  * the exit code of the child process.
  */
 describe('Electron Spec Runner', function () {
-  this.timeout(1000 * 30); // 30 seconds
+  this.timeout(1000 * 60); // 60 seconds
 
   it('should complete Electron tests successfully', (done) => {
     const runnerPath = path.resolve(__dirname, './spec-runner.ts');


### PR DESCRIPTION
#### Description of Change
- Wait for Devtron's Service Worker to start using `serviceWorkers.on('running-status-changed', listener)` instead of relying on `setTimeout`.
- Increase the delay to ensure IPC events are fully processed before running tests.
- Potentially fixes random test flakiness.
