### PR TITLE
build(dev-deps): bump Electron versions to latest for each major

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "copy-webpack-plugin": "^13.0.0",
     "cross-env": "^7.0.3",
     "css-loader": "^7.1.2",
-    "electron": "^39.8.4",
+    "electron": "^43.4.0",
     "electron36": "npm:electron@^36",
     "electron37": "npm:electron@^37",
     "electron38": "npm:electron@^38",

--- a/yarn.lock
+++ b/yarn.lock
@@ -3555,21 +3555,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron43@npm:electron@^43":
-  version: 43.4.0
-  resolution: "electron@npm:43.4.0"
-  dependencies:
-    "@electron-internal/extract-zip": "npm:^1.0.1"
-    "@electron/get": "npm:^5.0.0"
-    "@types/node": "npm:^24.9.0"
-  bin:
-    electron: cli.js
-    install-electron: install.js
-  checksum: 10c0/8b03553d1a5d186d4d95f80195ff634f6afd4ea9db7e09fdc67f251f93e7e2447da9a233e05281289450335ad8a01630609ffb5f3467ab38e71b65be489c9342
-  languageName: node
-  linkType: hard
-
-"electron@npm:^43.4.0":
+"electron43@npm:electron@^43, electron@npm:^43.4.0":
   version: 43.4.0
   resolution: "electron@npm:43.4.0"
   dependencies:

--- a/yarn.lock
+++ b/yarn.lock
@@ -3502,74 +3502,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron39@npm:electron@^39":
-  version: 39.8.5
-  resolution: "electron@npm:39.8.5"
-  dependencies:
-    "@electron/get": "npm:^2.0.0"
-    "@types/node": "npm:^22.7.7"
-    extract-zip: "npm:^2.0.1"
-  bin:
-    electron: cli.js
-  checksum: 10c0/21448e3d69a5e96912ce84533d39e7258be17879502cfed30bcdd6581b61516a1d1f3b492aad20344367967229bce27018625047f7ee6801257df93bf6b96d97
-  languageName: node
-  linkType: hard
-
-"electron40@npm:electron@^40":
-  version: 40.8.5
-  resolution: "electron@npm:40.8.5"
-  dependencies:
-    "@electron/get": "npm:^2.0.0"
-    "@types/node": "npm:^24.9.0"
-    extract-zip: "npm:^2.0.1"
-  bin:
-    electron: cli.js
-  checksum: 10c0/3874115299b101bada7f243afd1e0479c88a11fa534171a3d60d7933f4f0c382ef8e58aeaf91c963a2bb4d087ef3cd68065796b611a1dbaeb4b1205e680a23bd
-  languageName: node
-  linkType: hard
-
-"electron41@npm:electron@^41":
-  version: 41.5.0
-  resolution: "electron@npm:41.5.0"
-  dependencies:
-    "@electron/get": "npm:^2.0.0"
-    "@types/node": "npm:^24.9.0"
-    extract-zip: "npm:^2.0.1"
-  bin:
-    electron: cli.js
-  checksum: 10c0/5d311e7d411cc5372a6f1eed644776353a781c63122bfc8e70ef00bf5aaf78293e4bca8ccbbacbd7217c7ce72b35e25e4f9f97ced974d97e24e9912e570ee7c5
-  languageName: node
-  linkType: hard
-
-"electron42@npm:electron@^42":
-  version: 42.0.0
-  resolution: "electron@npm:42.0.0"
-  dependencies:
-    "@electron/get": "npm:^5.0.0"
-    "@types/node": "npm:^24.9.0"
-    extract-zip: "npm:^2.0.1"
-  bin:
-    electron: cli.js
-    install-electron: install.js
-  checksum: 10c0/72d7e7947216ef4d5e94e52e0e2dc6e6e2fc7ce296f9073da2d3cc4a1e7bd77790f603a26afeb88febcd4c3c5b16c45f5c0f3f0a3e68e64ac1b0d83742598906
-  languageName: node
-  linkType: hard
-
-"electron43@npm:electron@^43":
-  version: 43.0.0
-  resolution: "electron@npm:43.0.0"
-  dependencies:
-    "@electron-internal/extract-zip": "npm:^1.0.1"
-    "@electron/get": "npm:^5.0.0"
-    "@types/node": "npm:^24.9.0"
-  bin:
-    electron: cli.js
-    install-electron: install.js
-  checksum: 10c0/9f0bfb4e55dd97102941d009ce44ea1c5aa82325e877733284d75be8880ead11305ff45198d059e5127b441c94391ed159136cee23f2474e2416e2bbab2e9940
-  languageName: node
-  linkType: hard
-
-"electron@npm:^39.8.4":
+"electron39@npm:electron@^39, electron@npm:^39.8.4":
   version: 39.8.10
   resolution: "electron@npm:39.8.10"
   dependencies:
@@ -3579,6 +3512,60 @@ __metadata:
   bin:
     electron: cli.js
   checksum: 10c0/a62fc5a9d2cf96b4684547e14d2a9a1dc4350d66bcfdd2747d4154d6af3bdf8e4e0aae21dfaee55617035b870a3326b61102ef84b7bed5cd73040ec9b0ebe595
+  languageName: node
+  linkType: hard
+
+"electron40@npm:electron@^40":
+  version: 40.10.6
+  resolution: "electron@npm:40.10.6"
+  dependencies:
+    "@electron-internal/extract-zip": "npm:^1.0.1"
+    "@electron/get": "npm:^5.0.0"
+    "@types/node": "npm:^24.9.0"
+  bin:
+    electron: cli.js
+  checksum: 10c0/1026222c44d48e76c3e9990e587f25f51131fd9d68983634445cadd03438c4a2583007284a8d4233ad68c12cabadde9173b400b33f9b5940ba3360ea9e011783
+  languageName: node
+  linkType: hard
+
+"electron41@npm:electron@^41":
+  version: 41.10.5
+  resolution: "electron@npm:41.10.5"
+  dependencies:
+    "@electron-internal/extract-zip": "npm:^1.0.1"
+    "@electron/get": "npm:^5.0.0"
+    "@types/node": "npm:^24.9.0"
+  bin:
+    electron: cli.js
+  checksum: 10c0/25239f3efe5dc4f2c35419a2d8a640e5315df3dd874397976e9e512767d7ed1ca19b8645dc67381f7028f3432294c02383267e70f2bad596283da6d4e9e0671c
+  languageName: node
+  linkType: hard
+
+"electron42@npm:electron@^42":
+  version: 42.9.0
+  resolution: "electron@npm:42.9.0"
+  dependencies:
+    "@electron-internal/extract-zip": "npm:^1.0.1"
+    "@electron/get": "npm:^5.0.0"
+    "@types/node": "npm:^24.9.0"
+  bin:
+    electron: cli.js
+    install-electron: install.js
+  checksum: 10c0/8435017e9a265653d71bba60fbd9854a0390707fa61c00689c1e495770ede52a3212c5825ef51e176332bbe675012bb7b3e0363e03092a378d51676f85cae940
+  languageName: node
+  linkType: hard
+
+"electron43@npm:electron@^43":
+  version: 43.4.0
+  resolution: "electron@npm:43.4.0"
+  dependencies:
+    "@electron-internal/extract-zip": "npm:^1.0.1"
+    "@electron/get": "npm:^5.0.0"
+    "@types/node": "npm:^24.9.0"
+  bin:
+    electron: cli.js
+    install-electron: install.js
+  checksum: 10c0/8b03553d1a5d186d4d95f80195ff634f6afd4ea9db7e09fdc67f251f93e7e2447da9a233e05281289450335ad8a01630609ffb5f3467ab38e71b65be489c9342
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -633,7 +633,7 @@ __metadata:
     cross-env: "npm:^7.0.3"
     css-loader: "npm:^7.1.2"
     denque: "npm:^2.1.0"
-    electron: "npm:^39.8.4"
+    electron: "npm:^43.4.0"
     electron36: "npm:electron@^36"
     electron37: "npm:electron@^37"
     electron38: "npm:electron@^38"
@@ -3502,7 +3502,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"electron39@npm:electron@^39, electron@npm:^39.8.4":
+"electron39@npm:electron@^39":
   version: 39.8.10
   resolution: "electron@npm:39.8.10"
   dependencies:
@@ -3556,6 +3556,20 @@ __metadata:
   linkType: hard
 
 "electron43@npm:electron@^43":
+  version: 43.4.0
+  resolution: "electron@npm:43.4.0"
+  dependencies:
+    "@electron-internal/extract-zip": "npm:^1.0.1"
+    "@electron/get": "npm:^5.0.0"
+    "@types/node": "npm:^24.9.0"
+  bin:
+    electron: cli.js
+    install-electron: install.js
+  checksum: 10c0/8b03553d1a5d186d4d95f80195ff634f6afd4ea9db7e09fdc67f251f93e7e2447da9a233e05281289450335ad8a01630609ffb5f3467ab38e71b65be489c9342
+  languageName: node
+  linkType: hard
+
+"electron@npm:^43.4.0":
   version: 43.4.0
   resolution: "electron@npm:43.4.0"
   dependencies:


### PR DESCRIPTION
This also bumps the standalone `electron` version in `devDependencies` to the latest stable line. This should hopefully clear out some Dependabot alerts - it gets real confused on this repo due to the multiple majors of Electron.